### PR TITLE
Added support for Finagle's configuration items.

### DIFF
--- a/trinity-core/src/main/scala/org/sisioh/trinity/domain/mvc/server/ServerConfig.scala
+++ b/trinity-core/src/main/scala/org/sisioh/trinity/domain/mvc/server/ServerConfig.scala
@@ -58,7 +58,11 @@ case class ServerConfig
  maxConcurrentRequests: Option[Int] = None,
  hostConnectionMaxIdleTime: Option[Duration] = None,
  hostConnectionMaxLifeTime: Option[Duration] = None,
- requestTimeout: Option[Int] = None,
+ requestTimeout: Option[Duration] = None,
+ readTimeout: Option[Duration] = None,
+ writeCompletionTimeout: Option[Duration] = None,
+ sendBufferSize: Option[Int] = None,
+ receiveBufferSize: Option[Int] = None,
  newSSLEngine: Option[() => Engine] = None,
  tlsConfig: Option[TlsConfig] = None)
 

--- a/trinity-core/src/main/scala/org/sisioh/trinity/domain/mvc/server/ServerConfigLoader.scala
+++ b/trinity-core/src/main/scala/org/sisioh/trinity/domain/mvc/server/ServerConfigLoader.scala
@@ -20,6 +20,7 @@ import java.net.InetSocketAddress
 import org.sisioh.trinity.domain.mvc.Environment
 import org.sisioh.config.{ConfigurationMode, Configuration}
 import scala.util.{Failure, Try}
+import scala.concurrent.duration.Duration
 
 object ServerConfigLoader extends ServerConfigLoader
 
@@ -81,6 +82,17 @@ class ServerConfigLoader {
       },
       statsEnabled = configuration.getBooleanValue(getKeyName("stats.Enabled", prefix)).getOrElse(false),
       statsPort = configuration.getIntValue(getKeyName("stats.port", prefix)),
+      maxRequestSize = configuration.getIntValue(getKeyName("maxRequestSize", prefix)),
+      maxResponseSize = configuration.getIntValue(getKeyName("maxResponseSize", prefix)),
+      maxConcurrentRequests = configuration.getIntValue(getKeyName("maxConcurrentRequests", prefix)),
+      hostConnectionMaxIdleTime = configuration.getStringValue(getKeyName("hostConnectionMaxIdleTime", prefix)).map(Duration(_)),
+      hostConnectionMaxLifeTime = configuration.getStringValue(getKeyName("hostConnectionMaxLifeTime", prefix)).map(Duration(_)),
+      requestTimeout = configuration.getStringValue(getKeyName("requestTimeout", prefix)).map(Duration(_)),
+      readTimeout = configuration.getStringValue(getKeyName("readTimeout", prefix)).map(Duration(_)),
+      writeCompletionTimeout = configuration.getStringValue(getKeyName("writeCompletionTimeout", prefix)).map(Duration(_)),
+      sendBufferSize = configuration.getIntValue(getKeyName("sendBufferSize", prefix)),
+      receiveBufferSize = configuration.getIntValue(getKeyName("receiveBufferSize", prefix)),
+      newSSLEngine = None,
       tlsConfig = loadTlsConfig(configuration, prefix)
     )
     serverConfiguration


### PR DESCRIPTION
Previously, the trinity-core didn't support some parts of Finagle's configuration items, but it was supported.
The class represents the configuration items are the `org.sisioh.trinity.domain.mvc.server.ServerConfig` class. 

The configuration items can also be loaded from the configuration file.The followings is the configuration items.
- maxRequestSize
- maxResponseSize
- maxConcurrentRequests
- hostConnectionMaxIdleTime
- hostConnectionMaxLifeTime
- requestTimeout
- readTimeout
- writeCompletionTimeout
- sendBufferSize
- receiveBufferSize
