### PR TITLE
add test server info(host and port) into the test context

### DIFF
--- a/trinity-test/src/main/scala/org/sisioh/trinity/test/ControllerTestSupport.scala
+++ b/trinity-test/src/main/scala/org/sisioh/trinity/test/ControllerTestSupport.scala
@@ -1,26 +1,25 @@
 package org.sisioh.trinity.test
 
-import com.twitter.finagle.http.{Request => FinagleRequest, RequestBuilder, Method}
+import com.twitter.finagle.http.{Method, RequestBuilder, Request => FinagleRequest}
 import java.util.concurrent.TimeUnit
-import org.jboss.netty.handler.codec.http.{HttpHeaders, HttpMethod}
+import org.jboss.netty.buffer.ChannelBuffers
+import org.jboss.netty.handler.codec.http.HttpMethod
+import org.jboss.netty.util.CharsetUtil
 import org.sisioh.trinity.domain.io.http.HeaderName
 import org.sisioh.trinity.domain.mvc.GlobalSettings
 import org.sisioh.trinity.domain.mvc.http.{Request, Response}
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.Duration
 import scala.util.Try
-import org.jboss.netty.util.CharsetUtil
-import org.jboss.netty.buffer.ChannelBuffers
 
 trait ControllerTestSupport {
 
+  case class TestServer(host: Option[String] = None, port: Option[Int] = None)
+
   trait TestContext {
+    val server: TestServer
     val executor: ExecutionContext
   }
-
-  protected val serverHost: Option[String] = None
-
-  protected val serverPort: Option[Int] = None
 
   protected val globalSettings: Option[GlobalSettings[Request, Response]] = None
 
@@ -40,48 +39,46 @@ trait ControllerTestSupport {
    * @return [[com.twitter.finagle.http.Request]]
    */
   protected def newRequest
-  (method: HttpMethod,
-   path: String,
-   content: Option[Content],
-   headers: Map[HeaderName, String]): FinagleRequest = {
-      val host = serverHost.getOrElse(defaultHost)
-      val port = serverPort.getOrElse(defaultPort)
-      def url = "http://" + host + ":" + port
-      val request = content match {
-        case Some(StringContent(v)) if method == Method.Post =>
-          val httpRequest = RequestBuilder().url(url + path).
-            build(method, Some(ChannelBuffers.copiedBuffer(v, CharsetUtil.UTF_8)))
-          FinagleRequest(httpRequest)
-        case Some(MapContent(v)) if method == Method.Post =>
-          val httpRequest = RequestBuilder().url(url + path).
-            addFormElement(v.toSeq:_*).buildFormPost(false)
-          FinagleRequest(httpRequest)
-        case Some(MapContent(v)) if method == Method.Get =>
-          val params = v map {
-            case (key, value) =>
-              key + '=' + value
-          } mkString("?", "&", "")
-          val httpRequest = RequestBuilder.safeBuildGet(
-            RequestBuilder.create().url(url + path + params)
-          )
-          FinagleRequest(httpRequest)
-        case None if method == Method.Get =>
-          val httpRequest = RequestBuilder().url(url + path).buildGet()
-          FinagleRequest(httpRequest)
-        case None if method == Method.Post =>
-          val httpRequest = RequestBuilder().url(url + path).build(method, None)
-          FinagleRequest(httpRequest)
-        case Some(_) if method == Method.Get =>
-          throw new IllegalArgumentException("Illegal request argument")
-        case _ =>
-          throw new IllegalArgumentException("Illegal request argument")
-      }
-      headers.foreach {
-        header =>
-          request.httpRequest.headers.set(header._1.asString, header._2)
-      }
-      request
+  (method: HttpMethod, path: String, content: Option[Content], headers: Map[HeaderName, String])
+  (implicit testContext: TestContext): FinagleRequest = {
+    val host = testContext.server.host.getOrElse(defaultHost)
+    val port = testContext.server.port.getOrElse(defaultPort)
+    def url = "http://" + host + ":" + port
+    val request = content match {
+      case Some(StringContent(v)) if method == Method.Post =>
+        val httpRequest = RequestBuilder().url(url + path).
+          build(method, Some(ChannelBuffers.copiedBuffer(v, CharsetUtil.UTF_8)))
+        FinagleRequest(httpRequest)
+      case Some(MapContent(v)) if method == Method.Post =>
+        val httpRequest = RequestBuilder().url(url + path).
+          addFormElement(v.toSeq: _*).buildFormPost(false)
+        FinagleRequest(httpRequest)
+      case Some(MapContent(v)) if method == Method.Get =>
+        val params = v map {
+          case (key, value) =>
+            key + '=' + value
+        } mkString("?", "&", "")
+        val httpRequest = RequestBuilder.safeBuildGet(
+          RequestBuilder.create().url(url + path + params)
+        )
+        FinagleRequest(httpRequest)
+      case None if method == Method.Get =>
+        val httpRequest = RequestBuilder().url(url + path).buildGet()
+        FinagleRequest(httpRequest)
+      case None if method == Method.Post =>
+        val httpRequest = RequestBuilder().url(url + path).build(method, None)
+        FinagleRequest(httpRequest)
+      case Some(_) if method == Method.Get =>
+        throw new IllegalArgumentException("Illegal request argument")
+      case _ =>
+        throw new IllegalArgumentException("Illegal request argument")
     }
+    headers.foreach {
+      header =>
+        request.httpRequest.headers.set(header._1.asString, header._2)
+    }
+    request
+  }
 
   /**
    * テストのためのリクエストを生成する。

--- a/trinity-test/src/main/scala/org/sisioh/trinity/test/ControllerUnitTestSupport.scala
+++ b/trinity-test/src/main/scala/org/sisioh/trinity/test/ControllerUnitTestSupport.scala
@@ -25,7 +25,8 @@ trait ControllerUnitTestSupport extends ControllerTestSupport {
   self =>
 
   case class UnitTestContext(routingFilter: RoutingFilter,
-                             filters: Seq[Filter[Request, Response, Request, Response]] = Seq.empty)
+                             filters: Seq[Filter[Request, Response, Request, Response]] = Seq.empty,
+                             server: TestServer = TestServer())
                             (implicit val executor: ExecutionContext)
     extends TestContext
 
@@ -36,7 +37,7 @@ trait ControllerUnitTestSupport extends ControllerTestSupport {
    headers: Map[HeaderName, String], timeout: Duration)
   (implicit testContext: TestContext): Try[Response] = {
     implicit val executor = testContext.executor
-    val UnitTestContext(routingFilter, filters) = testContext
+    val UnitTestContext(routingFilter, filters, _) = testContext
     val request = newRequest(method, path, content, headers)
     val serviceBuilder = new ServiceBuilder {
       val globalSettings: Option[GlobalSettings[Request, Response]] = self.globalSettings

--- a/trinity-test/src/test/scala/org/sisioh/trinity/test/ControllerUnitTestSupportSpec.scala
+++ b/trinity-test/src/test/scala/org/sisioh/trinity/test/ControllerUnitTestSupportSpec.scala
@@ -1,5 +1,6 @@
 package org.sisioh.trinity.test
 
+import java.net.InetSocketAddress
 import org.sisioh.trinity.domain.io.http.Methods._
 import org.sisioh.trinity.domain.mvc.action.SimpleAction
 import org.sisioh.trinity.domain.mvc.http.ResponseBuilder
@@ -24,6 +25,27 @@ class ControllerUnitTestSupportSpec extends Specification with ControllerUnitTes
             Get % "/hello" -> helloWorld
           )
       }
+      testGet("/hello") {
+        result =>
+          result must beSuccessfulTry.like {
+            case response =>
+              response.contentAsString() must_== "Hello World!"
+          }
+      }
+    }
+    "test get method by specifying the server" in {
+      val bindAddress = new InetSocketAddress("localhost", 17070)
+      val testServer = TestServer(host = Option(bindAddress.getHostName), port = Option(bindAddress.getPort))
+      val routingFilter = RoutingFilter.createForActions {
+        implicit pathPatternParser =>
+          Seq(
+            Get % "/hello" -> helloWorld
+          )
+      }
+      implicit val testContext = UnitTestContext(
+        routingFilter = routingFilter,
+        server = testServer
+      )
       testGet("/hello") {
         result =>
           result must beSuccessfulTry.like {


### PR DESCRIPTION
単体テストとインテグレーションテストでテストケースを実行する時にサーバーのホストとポートを指定できるようにしました。
globalSettingsやrequestTimeoutについては今回見送りました。後ほど別途PR出します。
